### PR TITLE
Fix start script for Node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "config:link": "shopify app config link",
     "dev": "remix dev",
     "build": "remix build",
-    "start": "remix-serve build",
+    "start": "remix-serve build/index.js",
     "generate": "shopify app generate",
     "deploy": "shopify app deploy",
     "config:use": "shopify app config use",

--- a/remix.config.cjs
+++ b/remix.config.cjs
@@ -15,7 +15,7 @@ module.exports = {
   ignoredRouteFiles: ["**/.*"],
   serverBuildTarget: 'vercel',
   server: './server.mjs',
-  serverBuildDirectory: "dist",
+  serverBuildDirectory: "build",
   appDirectory: "app",
   serverModuleFormat: "cjs",
   dev: { port: process.env.HMR_SERVER_PORT || 8002 },


### PR DESCRIPTION
## Summary
- reference build entry file explicitly for remix-serve
- align server build directory with build output

## Testing
- `npm run build` *(fails: remix not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685f6568c25c8330a734da174a72521c